### PR TITLE
Better fix for virus spawning, no infinite loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+#### 1.6.3
+* Fixed safe spawning of virus, mother, and player cells
+
 #### 1.6.2
 * Optimised food and virus cell spawning and removal model (no longer use a spawning interval).
 * Removed unused gamemodes.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "MultiOgarII",
-    "version": "1.6.2",
+    "version": "1.6.3",
     "description": "Open source multi-protocol Ogar server",
     "author": "Megabyte918 (https://github.com/Megabyte918)",
     "homepage": "https://github.com/Megabyte918/MultiOgarII",

--- a/src/Server.js
+++ b/src/Server.js
@@ -664,13 +664,17 @@ class Server {
             this.border.miny + this.border.height * Math.random());
     }
     safeSpawn(cell) {
+        const maxAttempts = 10;
+
         var spawnSuccess = false;
-        while (!spawnSuccess) {
+        var attempts = 0;
+        while (!spawnSuccess && attempts < maxAttempts) {
             if (!this.willCollide(cell)) {
                 spawnSuccess = true;
             }
             else {
                 cell.position = this.randomPos();
+                attempts++;
             }
         }
         this.addNode(cell);

--- a/src/Server.js
+++ b/src/Server.js
@@ -674,8 +674,17 @@ class Server {
     }
     spawnVirus() {
         var virus = new Entity.Virus(this, null, this.randomPos(), this.config.virusMinSize);
-        if (!this.willCollide(virus))
-            this.addNode(virus);
+        var spawnSuccess = false;
+        while (!spawnSuccess) {
+            if (!this.willCollide(virus)) {
+                this.addNode(virus);
+                spawnSuccess = true;
+            }
+            else {
+                virus.position = this.randomPos();
+            }
+        }
+        
     }
     spawnCells(virusCount, foodCount) {
         for (var i = 0; i < foodCount; i++) {
@@ -704,9 +713,17 @@ class Server {
         }
         // Spawn player safely (do not check minions)
         var cell = new Entity.PlayerCell(this, player, pos, size);
-        if (this.willCollide(cell) && !player.isMi)
-            pos = this.randomPos(); // Not safe => retry
-        this.addNode(cell);
+        var spawnSuccess = false;
+        while (!spawnSuccess) {
+            if (this.willCollide(cell) && !player.isMi) {
+                cell.position = this.randomPos(); // Not safe => retry
+            }
+            else {
+                this.addNode(cell);
+                spawnSuccess = true;
+            }
+        }
+        
         // Set initial mouse coords
         player.mouse.assign(pos);
     }

--- a/src/Server.js
+++ b/src/Server.js
@@ -663,6 +663,18 @@ class Server {
         return new Vec2(this.border.minx + this.border.width * Math.random(),
             this.border.miny + this.border.height * Math.random());
     }
+    safeSpawn(cell) {
+        var spawnSuccess = false;
+        while (!spawnSuccess) {
+            if (!this.willCollide(cell)) {
+                spawnSuccess = true;
+            }
+            else {
+                cell.position = this.randomPos();
+            }
+        }
+        this.addNode(cell);
+    }
     spawnFood() {
         var cell = new Entity.Food(this, null, this.randomPos(), this.config.foodMinSize);
         if (this.config.foodMassGrow) {
@@ -674,16 +686,7 @@ class Server {
     }
     spawnVirus() {
         var virus = new Entity.Virus(this, null, this.randomPos(), this.config.virusMinSize);
-        var spawnSuccess = false;
-        while (!spawnSuccess) {
-            if (!this.willCollide(virus)) {
-                this.addNode(virus);
-                spawnSuccess = true;
-            }
-            else {
-                virus.position = this.randomPos();
-            }
-        }
+        this.safeSpawn(virus);
         
     }
     spawnCells(virusCount, foodCount) {
@@ -713,15 +716,11 @@ class Server {
         }
         // Spawn player safely (do not check minions)
         var cell = new Entity.PlayerCell(this, player, pos, size);
-        var spawnSuccess = false;
-        while (!spawnSuccess) {
-            if (this.willCollide(cell) && !player.isMi) {
-                cell.position = this.randomPos(); // Not safe => retry
-            }
-            else {
-                this.addNode(cell);
-                spawnSuccess = true;
-            }
+        if (!player.isMi) {
+            this.addNode(cell);
+        }
+        else {
+            this.safeSpawn(cell);
         }
         
         // Set initial mouse coords

--- a/src/Server.js
+++ b/src/Server.js
@@ -26,7 +26,7 @@ class Server {
 
         // Startup
         this.run = true;
-        this.version = '1.6.2';
+        this.version = '1.6.3';
         this.httpServer = null;
         this.lastNodeId = 1;
         this.lastPlayerId = 1;

--- a/src/gamemodes/Experimental.js
+++ b/src/gamemodes/Experimental.js
@@ -21,8 +21,16 @@ class Experimental extends FFA {
         }
         // Spawn if no cells are colliding
         var mother = new Entity.MotherCell(server, null, server.randomPos(), 149);
-        if (!server.willCollide(mother))
-            server.addNode(mother);
+        var spawnSuccess = false;
+        while (!spawnSuccess) {
+            if (!server.willCollide(mother)) {
+                server.addNode(mother);
+                spawnSuccess = true;
+            }
+            else {
+                mother.position = server.randomPos();
+            }
+        }
     }
     // Override
     onServerInit(server) {

--- a/src/gamemodes/Experimental.js
+++ b/src/gamemodes/Experimental.js
@@ -21,15 +21,7 @@ class Experimental extends FFA {
         }
         // Spawn if no cells are colliding
         var mother = new Entity.MotherCell(server, null, server.randomPos(), 149);
-        var spawnSuccess = false;
-        while (!spawnSuccess) {
-            if (!server.willCollide(mother)) {
-                server.addNode(mother);
-                spawnSuccess = true;
-            }
-            else {
-                mother.position = server.randomPos();
-            }
+        server.safeSpawn(mother);
         }
     }
     // Override

--- a/src/gamemodes/Experimental.js
+++ b/src/gamemodes/Experimental.js
@@ -22,7 +22,6 @@ class Experimental extends FFA {
         // Spawn if no cells are colliding
         var mother = new Entity.MotherCell(server, null, server.randomPos(), 149);
         server.safeSpawn(mother);
-        }
     }
     // Override
     onServerInit(server) {


### PR DESCRIPTION
As you can see I've fixed some duplicated code by making safeSpawn a method of Server, but more importantly I've put in a simple 10-loop limit that will prevent an infinite loop if a cell fails to spawn safely.

Feel free to close if you're already working on a better solution.